### PR TITLE
Avoiding Warnings

### DIFF
--- a/model.py
+++ b/model.py
@@ -114,7 +114,7 @@ class Discriminator(nn.Module):
 
 def kaiming_init(m):
     if isinstance(m, (nn.Linear, nn.Conv2d)):
-        init.kaiming_normal(m.weight)
+        init.kaiming_normal_(m.weight)
         if m.bias is not None:
             m.bias.data.fill_(0)
     elif isinstance(m, (nn.BatchNorm1d, nn.BatchNorm2d)):

--- a/solver.py
+++ b/solver.py
@@ -88,8 +88,9 @@ class Solver:
                 transductive_loss = self.vae_loss(unlabeled_imgs, 
                         unlab_recon, unlab_mu, unlab_logvar, self.args.beta)
             
-                labeled_preds = discriminator(mu)
-                unlabeled_preds = discriminator(unlab_mu)
+                labeled_preds = discriminator(mu).view(-1)
+                unlabeled_preds = discriminator(unlab_mu).view(-1)
+
                 
                 lab_real_preds = torch.ones(labeled_imgs.size(0))
                 unlab_real_preds = torch.ones(unlabeled_imgs.size(0))
@@ -121,8 +122,9 @@ class Solver:
                     _, _, mu, _ = vae(labeled_imgs)
                     _, _, unlab_mu, _ = vae(unlabeled_imgs)
                 
-                labeled_preds = discriminator(mu)
-                unlabeled_preds = discriminator(unlab_mu)
+                labeled_preds = discriminator(mu).view(-1)
+                unlabeled_preds = discriminator(unlab_mu).view(-1)
+
                 
                 lab_real_preds = torch.ones(labeled_imgs.size(0))
                 unlab_fake_preds = torch.zeros(unlabeled_imgs.size(0))


### PR DESCRIPTION
1. ​  In Model.py 
 init.kaiming_normal(m.weight) to init.kaiming_normal_(m.weight)
(initial one is giving a warning )

2. In Solver.py added view(-1) in 2 places
As BCELoss gives warning if tensors are of different sizes [128,1], [128]
 labeled_preds = discriminator(mu).view(-1)
 unlabeled_preds = discriminator(unlab_mu).view(-1)
   
   